### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "Digest::PSHA1",
+    "license" : "MIT",
     "version" : "1.0.0",
     "author" : "github:FROGGS",
     "description" : "pseudorandom hashing algorithm as per rfc5246",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license